### PR TITLE
Add Sinatra app to interface with AutoAMI

### DIFF
--- a/ext/sinatra/autoami.rb
+++ b/ext/sinatra/autoami.rb
@@ -1,0 +1,26 @@
+require 'rubygems'
+require 'sinatra'
+require 'puppet/face'
+
+## This needs to be a Torquebox app
+
+class AutoAMI < Sinatra::Base
+
+  get '/run' do
+    fork {
+      Puppet::Face[:autoami, :current].run
+    }
+    "Running AutoAMI in the background"
+  end
+
+  get '/launch/:group' do
+    fork {
+      Puppet::Face[:node_aws, :current].launch params[:group]
+    }
+    "Launching AutoAMI #{params[:group]} group in the background"
+  end
+
+  get '/list' do
+    Puppet::Face[:node_aws, :current].list.to_yaml
+  end
+end

--- a/ext/sinatra/config.ru
+++ b/ext/sinatra/config.ru
@@ -1,0 +1,4 @@
+require 'rack'
+require "#{File.dirname(__FILE__)}/autoami"
+
+run AutoAMI


### PR DESCRIPTION
This commit adds a Sinatra app that allows for HTTP requests to be made
to AutoAMI.  This particularly useful for triggering runs from remote
systems, such as a Jenkins box or Githubpuppet-autoami